### PR TITLE
building eleanor compatability, handling non-square postcards

### DIFF
--- a/tess_cpm/cpm_model.py
+++ b/tess_cpm/cpm_model.py
@@ -102,13 +102,15 @@ class CPM(object):
         r = self.target_row  # just to reduce verbosity for this function
         c = self.target_col
         self.exclusion_size = exclusion_size
-        sidelength = self.cutout_data.cutout_sidelength
+        sidelength_x = self.cutout_data.cutout_sidelength_x
+        sidelength_y = self.cutout_data.cutout_sidelength_y
+        
 
         excluded_pixels = np.full(self.cutout_data.fluxes[0].shape, False)
         if method == "closest":
             excluded_pixels[
-                max(0, r - exclusion_size) : min(r + exclusion_size + 1, sidelength),
-                max(0, c - exclusion_size) : min(c + exclusion_size + 1, sidelength),
+                max(0, r - exclusion_size) : min(r + exclusion_size + 1, sidelength_x),
+                max(0, c - exclusion_size) : min(c + exclusion_size + 1, sidelength_y),
             ] = True
         if method == "cross":
             excluded_pixels[
@@ -163,10 +165,12 @@ class CPM(object):
 
         self.method_choose_predictor_pixels = method
         self.num_predictor_pixels = n
-        sidelength = self.cutout_data.cutout_sidelength
+        sidelength_x = self.cutout_data.cutout_sidelength_x
+        sidelength_y = self.cutout_data.cutout_sidelength_y
+        
 
         # I'm going to do this in 1D by assinging individual pixels a single index instead of two.
-        coordinate_idx = np.arange(sidelength ** 2)
+        coordinate_idx = np.arange(sidelength_x * sidelength_y)
         valid_idx = coordinate_idx[~self.mask_excluded_pixels.ravel()]
         # valid_idx = coordinate_idx[self.excluded_pixels_mask.mask.ravel()]
 
@@ -193,7 +197,7 @@ class CPM(object):
             chosen_idx = valid_idx[np.argsort(diff)[0:n]]
 
         self.locations_predictor_pixels = np.array(
-            [[idx // sidelength, idx % sidelength] for idx in chosen_idx]
+            [[idx // sidelength_y, idx % sidelength_y] for idx in chosen_idx]
         )
         loc = self.locations_predictor_pixels.T
         mask = np.full(self.cutout_data.fluxes[0].shape, False)

--- a/tess_cpm/cutout_data.py
+++ b/tess_cpm/cutout_data.py
@@ -13,27 +13,50 @@ class CutoutData(object):
         path (str): path to file
         remove_bad (bool): If ``True``, remove the data points that have been flagged by the TESS team. Default is ``True``.
         verbose (bool): If ``True``, print statements containing information. Default is ``True``.
+        provenance (str): If ``TessCut``, the image being passed through is a TessCut cutout. If ``eleanor``, it is an eleanor postcard.
 
     """
 
-    def __init__(self, path, remove_bad=True, verbose=True):
+    def __init__(self, path, remove_bad=True, verbose=True, provenance='TessCut'):
         self.file_path = path
         self.file_name = path.split("/")[-1]
-        s = self.file_name.split("-")
-        self.sector = s[1].strip("s").lstrip("0")
-        self.camera = s[2]
-        self.ccd = s[3][0]
+        
+        if provenance == 'TessCut':
+            s = self.file_name.split("-")
+            self.sector = s[1].strip("s").lstrip("0")
+            self.camera = s[2]
+            self.ccd = s[3][0]
 
-        with fits.open(path, mode="readonly") as hdu:
-            self.time = hdu[1].data["TIME"]
-            self.fluxes = hdu[1].data["FLUX"]
-            self.flux_errors = hdu[1].data["FLUX_ERR"]
-            self.quality = hdu[1].data["QUALITY"]
-            try:
-                self.wcs_info = WCS(hdu[2].header)  # pylint: disable=no-member
-            except Exception as inst:
-                print(inst)
-                print("WCS Info could not be retrieved")
+            with fits.open(path, mode="readonly") as hdu:
+                self.time = hdu[1].data["TIME"]
+                self.fluxes = hdu[1].data["FLUX"]
+                self.flux_errors = hdu[1].data["FLUX_ERR"]
+                self.quality = hdu[1].data["QUALITY"]
+                try:
+                    self.wcs_info = WCS(hdu[2].header)  # pylint: disable=no-member
+                except Exception as inst:
+                    print(inst)
+                    print("WCS Info could not be retrieved")
+        
+        elif provenance == 'eleanor':
+            with fits.open(path, mode="readonly") as hdu:
+                self.sector = int(hdu[2].header["SECTOR"])
+                self.camera = int(hdu[2].header["CAMERA"])
+                self.ccd    = int(hdu[2].header["CCD"])
+
+                self.time = (hdu[1].data['TSTART'] + hdu[1].data['TSTOP'])/2
+                self.fluxes = hdu[2].data
+                self.flux_errors = hdu[3].data
+                self.quality = hdu[1].data['QUALITY']
+
+                try:
+                    self.wcs_info = WCS(hdu[2].header)  # pylint: disable=no-member
+                except Exception as inst:
+                    print(inst)
+                    print("WCS Info could not be retrieved")
+                    
+        else:
+            raise ValueError('Data provenance not understood. Pass through TessCut or eleanor')
 
         self.flagged_times = self.time[self.quality > 0]
         # If remove_bad is set to True, we'll remove the values with a nonzero entry in the quality array
@@ -51,14 +74,17 @@ class CutoutData(object):
         # We're going to precompute the pixel lightcurve medians since it's used to set the predictor pixels
         # but never has to be recomputed. np.nanmedian is used to handle images containing NaN values.
         self.flux_medians = np.nanmedian(self.fluxes, axis=0)
-        self.cutout_sidelength = self.fluxes[0].shape[0]
+        self.cutout_sidelength_x = self.fluxes[0].shape[0]
+        self.cutout_sidelength_y = self.fluxes[0].shape[1]
+        
         self.flattened_flux_medians = self.flux_medians.reshape(
-            self.cutout_sidelength ** 2
+            self.cutout_sidelength_x * self.cutout_sidelength_y
         )
         # We rescale the fluxes by dividing by the mean and then centering them around zero.
         self.normalized_fluxes = (self.fluxes / self.flux_medians) - 1
         self.flattened_normalized_fluxes = self.normalized_fluxes.reshape(
-            self.time.shape[0], self.cutout_sidelength ** 2
+            self.time.shape[0], 
+            self.cutout_sidelength_x * self.cutout_sidelength_y
         )
 
         self.normalized_flux_errors = self.flux_errors / self.flux_medians

--- a/tess_cpm/cutout_data.py
+++ b/tess_cpm/cutout_data.py
@@ -17,7 +17,7 @@ class CutoutData(object):
 
     """
 
-    def __init__(self, path, remove_bad=True, verbose=True, provenance='TessCut'):
+    def __init__(self, path, remove_bad=True, verbose=True, provenance='TessCut', quality=None):
         self.file_path = path
         self.file_name = path.split("/")[-1]
         
@@ -31,7 +31,10 @@ class CutoutData(object):
                 self.time = hdu[1].data["TIME"]
                 self.fluxes = hdu[1].data["FLUX"]
                 self.flux_errors = hdu[1].data["FLUX_ERR"]
-                self.quality = hdu[1].data["QUALITY"]
+                if quality is None:
+                    self.quality = hdu[1].data["QUALITY"]
+                else:
+                    self.quality = quality
                 try:
                     self.wcs_info = WCS(hdu[2].header)  # pylint: disable=no-member
                 except Exception as inst:
@@ -47,7 +50,10 @@ class CutoutData(object):
                 self.time = (hdu[1].data['TSTART'] + hdu[1].data['TSTOP'])/2
                 self.fluxes = hdu[2].data
                 self.flux_errors = hdu[3].data
-                self.quality = hdu[1].data['QUALITY']
+                if quality is None:
+                    self.quality = hdu[1].data['QUALITY']
+                else:
+                    self.quality = quality
 
                 try:
                     self.wcs_info = WCS(hdu[2].header)  # pylint: disable=no-member

--- a/tess_cpm/source.py
+++ b/tess_cpm/source.py
@@ -15,8 +15,9 @@ class Source(object):
 
     """
 
-    def __init__(self, path, remove_bad=True, verbose=True):
-        self.cutout_data = CutoutData(path, remove_bad, verbose)
+    def __init__(self, path, remove_bad=True, verbose=True, provenance='TessCut'):
+        self.provenance = provenance
+        self.cutout_data = CutoutData(path, remove_bad, verbose, self.provenance)
         self.time = self.cutout_data.time
         self.aperture = None
         self.models = None
@@ -27,6 +28,7 @@ class Source(object):
         self.split_predictions = None
         self.split_fluxes = None
         self.split_detrended_lcs = None
+
 
     def set_aperture(self, rowlims=[49, 51], collims=[49, 51]):
         self.models = []
@@ -120,12 +122,12 @@ class Source(object):
 
     def plot_cutout(self, rowlims=None, collims=None, l=10, h=90, show_aperture=False, projection=None):
         if rowlims is None:
-            rows = [0, self.cutout_data.cutout_sidelength]
+            rows = [0, self.cutout_data.cutout_sidelength_x]
         else:
             rows = rowlims
 
         if collims is None:
-            cols = [0, self.cutout_data.cutout_sidelength]
+            cols = [0, self.cutout_data.cutout_sidelength_y]
         else:
             cols = collims
         full_median_image = self.cutout_data.flux_medians

--- a/tess_cpm/source.py
+++ b/tess_cpm/source.py
@@ -234,12 +234,17 @@ class Source(object):
             aperture_lc = np.zeros_like(self.split_times)
         else:
             aperture_lc = np.zeros_like(self.time)
+        medvals = np.zeros((len(rows), len(cols)))
+        for r in rows:
+            for c in cols:
+                medvals[r][c] = self.models[r][c].cpm.target_median
+        medvals /= np.nansum(medvals)
         for r in rows:
             for c in cols:
                 if split:
-                    aperture_lc += self.models[r][c].split_values_dict[data_type]
+                    aperture_lc += medvals[r][c]*self.models[r][c].split_values_dict[data_type]
                 else:
-                    aperture_lc += self.models[r][c].values_dict[data_type]
+                    aperture_lc += medvals[r][c]*self.models[r][c].values_dict[data_type]
         return aperture_lc
 
     def _calc_cdpp(self, flux, **kwargs):

--- a/tess_cpm/source.py
+++ b/tess_cpm/source.py
@@ -15,9 +15,9 @@ class Source(object):
 
     """
 
-    def __init__(self, path, remove_bad=True, verbose=True, provenance='TessCut'):
+    def __init__(self, path, remove_bad=True, verbose=True, provenance='TessCut', quality=None):
         self.provenance = provenance
-        self.cutout_data = CutoutData(path, remove_bad, verbose, self.provenance)
+        self.cutout_data = CutoutData(path, remove_bad, verbose, self.provenance, quality)
         self.time = self.cutout_data.time
         self.aperture = None
         self.models = None


### PR DESCRIPTION
I wanted to be able to use this method with eleanor postcards, but there are a few hard-coded bits of information that assume you're getting a fits file as delivered by TessCut.

This pull requests adds a ```provenance``` keyword into the call to Source which tells the code whether the FITS file that's being loaded in is from TessCut or eleanor. If the user doesn't pass this through it defaults to TessCut. In the future this could be re-written to use the fits header information to figure out what the data source is, but I imagine these will be the two primary sources for the majority of users anyway.

Along the way I made a few other minor changes to handle non-square data frames; previously it assumed that the x and y length were the same.

Minimal working example:

```
import tess_cpm

fits_file = "hlsp_eleanor_tess_ffi_postcard-s0001-4-1-cal-0902-1078_tess_v2_pc.fits"
dw = tess_cpm.Source(fits_file, remove_bad=True, provenance='eleanor')
dw.plot_cutout()

fits_file = "tess-s0010-2-1_162.328812_-53.319467_100x100_astrocut.fits"
dw = tess_cpm.Source(fits_file, remove_bad=True) # could also pass through provenance='TessCut'
dw.plot_cutout()
```
